### PR TITLE
clarify origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Track gitlab pipelines state of your project.
    - If you don't know what they are, please refer to https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html,
    - `gitlab-integration` requires **api** access
  - Clone a project hosted on a gitlab server
-   - **warning** pay attention to the URL you use to clone your project. Indeed, `gitlab-integration` uses origin URL to determine where to reach Gitlab API to get pipeline statuses.
+   - **warning** pay attention to the URL you use to clone your project. Indeed, `gitlab-integration` uses `origin` URL to determine where to reach Gitlab API to get pipeline statuses.
  - Add the project to Atom or directly open a file from your project
  - `gitlab-integration` should display pipeline statuses in the status bar if it can correctly determine and reach the gitlab server where your project is hosted like shown above.
  - *In case any errors occurs, a message should be logged in Atom developer console.*


### PR DESCRIPTION
Had to read instructions 3 times before I realized that the plugin literally looks for the `origin` url. 