### PR TITLE
fixes #26.

### DIFF
--- a/lib/gitlab.coffee
+++ b/lib/gitlab.coffee
@@ -67,12 +67,16 @@ class GitlabStatus
             @view.loading projectPath, "loading project..."
             @fetch(host, "projects?membership=yes", true).then(
                 (projects) =>
+                    projects = projects.map(
+                        (project) =>
+                            project.path_with_namespace = project.path_with_namespace.toLowerCase()
+                            project
+                    )
                     log "received projects from #{host}", projects
                     if projects?
                         project = projects.filter(
                             (project) =>
-                                project.path_with_namespace.toLowerCase() is
-                                    projectPath
+                                project.path_with_namespace is projectPath
                         )[0]
                         if project?
                             @projects[projectPath] = { host, project, repos }


### PR DESCRIPTION
Gitlab returns case-sensitive path names for the project.
While the initial filter was caught with a toLowerCase() during update this was forgotten.
Replaced object property in gitlab response.